### PR TITLE
Add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
     "minimum-stability": "dev",
     "require-dev": {
         "phpunit/phpunit": "^9.2@dev",
-        "orchestra/testbench": "5.*"
+        "orchestra/testbench": "^3.6 || ^4.0 || ^5.0 || ^6.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "laravel/framework": "^5.6|^6|^7",
+        "laravel/framework": "^5.6 || ^6.0 || ^7.0 || ^8.0",
         "php": "^7.2.5",
         "react/socket": "^1.4"
     },


### PR DESCRIPTION
This PR will:

- Add support for Laravel 8
- Resolves #11 
- fix orchestra/testbench constraints:

 Laravel  | Testbench
:---------|:----------
 5.6.x    | 3.6.x
 5.7.x    | 3.7.x
 5.8.x    | 3.8.x
 6.x      | 4.x
 7.x      | 5.x
 8.x      | 6.x

![add-support-laravel-8](https://user-images.githubusercontent.com/6556083/94879086-a00e4680-0435-11eb-990f-c604b98fd358.png)
