### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+#
+# This way, the files would be available in the repository but it would not be downloaded when the package is required by another project.
+
+# Ignore with "export-ignore".
+/.gitattributes     export-ignore
+/.github            export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/demo.gif           export-ignore
+/phpunit.xml        export-ignore
+/tests              export-ignore


### PR DESCRIPTION
This way, the files would be available in the repository but it would not be downloaded when the package is required by another project.