### PR TITLE
Add configuration option to ignore queries based on regex matches

### DIFF
--- a/config/laravel-query-monitor.php
+++ b/config/laravel-query-monitor.php
@@ -4,4 +4,11 @@ return [
     'enable' => env('LARAVEL_QUERY_MONITOR', true),
     'host' => env('LARAVEL_QUERY_MONITOR_HOST', '0.0.0.0'),
     'port' => env('LARAVEL_QUERY_MONITOR_PORT', 8081),
+    
+    // The following options are used to filter the queries that are monitored.
+    // Useful to ignore queries from Laravel Pulse, Telescope, etc.
+    'ignore_query_match' => [
+        '/pulse_entries|pulse_aggregates|pulse_values/i',
+        '/telescope_entries|telescope_entries_tags|telescope_monitoring/i',
+    ],
 ];


### PR DESCRIPTION
For users that have other dev tools installed and running, this configuration is very useful to ignore queries generated by those other tools.
Especially when those tools run queries automatically every x seconds.
I included 2 default ignore parameters for Laravel Telescope and Laravel Pulse.